### PR TITLE
fix: Set kit.prerender.default=true for building pages

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,7 +8,10 @@ const config = {
 	preprocess: preprocess(),
 
 	kit: {
-		adapter: adapterStatic()
+		adapter: adapterStatic(),
+		prerender: {
+			default: true
+		}
 	}
 };
 


### PR DESCRIPTION
Page did not create `.html` pages anymore after a recent sveltekit update.